### PR TITLE
Fix Change Password Bug

### DIFF
--- a/assets/scripts/auth/ui.js
+++ b/assets/scripts/auth/ui.js
@@ -59,6 +59,8 @@ const signOutSuccess = function () {
   $('#previous-orders-button').addClass('d-none')
   $('#state-shopping-cart').addClass('d-none')
   $('#state-previous-orders').addClass('d-none')
+  $('#change-password-form input').val('')
+  $('#change-password-form').addClass('d-none')
 }
 
 const signOutFail = function () {


### PR DESCRIPTION
- Add `$('#change-password-form input').val('')
       $('#change-password-form').addClass('d-none')`
    to ui.js to hide the change-password form if a user signs out before
    filling it out.
    Previous version left the change password form on the screen after
    sign out if this happened 

#23 