### PR TITLE
Fix Remove From Cart Bug

### DIFF
--- a/assets/scripts/orders/ui.js
+++ b/assets/scripts/orders/ui.js
@@ -72,7 +72,8 @@ const showProductsOnly = function () {
 }
 
 const removeProductSuccess = function (lineitemId, priceElement) {
-  const productPrice = parseFloat(priceElement.text().substr(1))
+  let productPrice = parseFloat(priceElement.text().substr(1))
+  productPrice *= 100
   store.totalAmount -= productPrice
   $('#total .amount').html((store.totalAmount / 100).toFixed(2))
 


### PR DESCRIPTION
-Fix bug where the wrong dollar value was subtracted from the cart when
 an item was removed.
- in showCart in 'orders/ui.js' when an item is displayed in the cart,
   it's value in cents is reassigned to it's value in dollars. However,
   when an item was removed, the value was never switched back into
   cents. As a result, adding a $400 item to the cart provided a total
   of $400 and removing that same item yielded a total of $396, even
   though the cart was empty.
- fix this bug by convert the dollar value back to cents in
  'orders/ui.js' removeProductSuccess. #22 